### PR TITLE
Rename composer to compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ $md5 = function($string) {
 	return md5($string);
 };
 
-$composer = composer($upper, $md5, $exclamation);
+$compose = compose($upper, $md5, $exclamation);
 
-echo $composer("Hello"); // eb61eead90e3b899c6bcbe27ac581660!!!
+echo $compose("Hello"); // eb61eead90e3b899c6bcbe27ac581660!!!
 ```
 
 ### memoize

--- a/example.php
+++ b/example.php
@@ -14,9 +14,9 @@ $md5 = function($string) {
 	return md5($string);
 };
 
-$composer = composer($upper, $md5, $exclamation);
+$compose = compose($upper, $md5, $exclamation);
 
-echo $composer("Hello"); // eb61eead90e3b899c6bcbe27ac581660!!!
+echo $compose("Hello"); // eb61eead90e3b899c6bcbe27ac581660!!!
 
 /** Curry **/
 $sum = function($num1, $num2) { return $num1+$num2; };

--- a/src/extra/compose.php
+++ b/src/extra/compose.php
@@ -1,5 +1,5 @@
 <?PHP
-function composer(...$functions) {
+function compose(...$functions) {
 	return function($value) use ($functions) {
 		return array_reduce($functions, function($curry, $current) use ($value) {
 			return $current($curry??$value);

--- a/src/index.php
+++ b/src/index.php
@@ -1,6 +1,7 @@
 <?php
 // Recupera todos as funcões
-require './src/extra/composer.php';
+require './src/extra/compose.php';
 require './src/extra/curry.php';
 require './src/extra/memoize.php';
 require './src/extra/pipe.php';
+


### PR DESCRIPTION
Renomeei a função `composer` para `compose`, como é na biblioteca Pareto e no próprio README desse repositório :sunglasses: 